### PR TITLE
Support other lockfiles

### DIFF
--- a/lib/bundler/compat/conflict_finder.rb
+++ b/lib/bundler/compat/conflict_finder.rb
@@ -13,7 +13,7 @@ module Bundler
 
       attr_reader :lockfile, :target_version
 
-      def initialize(lockfile_contents: File.read("Gemfile.lock"), target_version: "8.1.0")
+      def initialize(lockfile_contents: File.read(Bundler.default_lockfile), target_version: "8.1.0")
         @target_version = Gem::Version.new(target_version)
         @lockfile = Bundler::LockfileParser.new(lockfile_contents)
         @spec_by_name = lockfile.specs


### PR DESCRIPTION
I think we can rely on Bundler's `.default_lockfile` method instead of hardcoding `Gemfile.lock` as the default.

```bash
ruby -r bundler -e "p Bundler.default_lockfile"
=> #<Pathname:/Users/nony.dutton/Code/example/Gemfile.lock>

BUNDLE_GEMFILE=Gemfile.next ruby -r bundler -e "p Bundler.default_lockfile"
=> #<Pathname:/Users/nony.dutton/Code/example/Gemfile.next.lock>
```