### PR TITLE
Use nested json schema and add target version to reports

### DIFF
--- a/lib/bundler/compat/reporters/base_reporter.rb
+++ b/lib/bundler/compat/reporters/base_reporter.rb
@@ -2,8 +2,9 @@ module Bundler
   module Compat
     module Reporters
       class BaseReporter
-        def initialize(results)
+        def initialize(results, target_version:)
           @results = results
+          @target_version = target_version
         end
 
         def print(results, output: $stdout)
@@ -12,12 +13,13 @@ module Bundler
 
         private
 
-        attr_reader :results
+        attr_reader :results, :target_version
 
         def preamble
           <<~REPORT.lines
             Bundle Compatibility Report
             #{"=" * 50}
+            Target Rails version: #{target_version}
             Found #{results.conflicts.size} conflicts(s)
 
           REPORT

--- a/plugins.rb
+++ b/plugins.rb
@@ -18,9 +18,9 @@ class BundlerCompatPlugin < Bundler::Plugin::API
 
       reporter = case format
       when "json"
-        Bundler::Compat::Reporters::JsonReporter.new(results)
+        Bundler::Compat::Reporters::JsonReporter.new(results, target_version: target_version)
       when "plain"
-        Bundler::Compat::Reporters::TextReporter.new(results)
+        Bundler::Compat::Reporters::TextReporter.new(results, target_version: target_version)
       else
         Bundler.ui.error "Invalid format: #{format}. Use 'json' or 'plain'."
         exit 1

--- a/test/bundler/test_json_reporter.rb
+++ b/test/bundler/test_json_reporter.rb
@@ -9,15 +9,16 @@ require "stringio"
 class TestJsonReporter < Minitest::Test
   def test_empty_results_json_output
     results = Bundler::Compat::Result::Group.new
-    reporter = Bundler::Compat::Reporters::JsonReporter.new(results)
+    reporter = Bundler::Compat::Reporters::JsonReporter.new(results, target_version: "7.0.0")
 
     output = StringIO.new
     reporter.print(output: output)
 
     json_data = JSON.parse(output.string)
 
-    assert_equal 0, json_data["bundle_compatibility_report"]["conflicts_count"]
-    assert_equal [], json_data["bundle_compatibility_report"]["conflicts"]
+    assert_equal "7.0.0", json_data["target_rails_version"]
+    assert_equal 0, json_data["conflicts_count"]
+    assert_equal [], json_data["conflicts"]
   end
 
   def test_single_conflict_json_output
@@ -35,25 +36,29 @@ class TestJsonReporter < Minitest::Test
     results = Bundler::Compat::Result::Group.new
     results.add(conflict)
 
-    reporter = Bundler::Compat::Reporters::JsonReporter.new(results)
+    reporter = Bundler::Compat::Reporters::JsonReporter.new(results, target_version: "7.0.0")
 
     output = StringIO.new
     reporter.print(output: output)
 
     json_data = JSON.parse(output.string)
 
-    assert_equal 1, json_data["bundle_compatibility_report"]["conflicts_count"]
-    assert_equal 1, json_data["bundle_compatibility_report"]["conflicts"].size
+    assert_equal "7.0.0", json_data["target_rails_version"]
+    assert_equal 1, json_data["conflicts_count"]
+    assert_equal 1, json_data["conflicts"].size
 
-    conflict_data = json_data["bundle_compatibility_report"]["conflicts"].first
-    assert_equal "rails", conflict_data["direct_dependency"]
-    assert_equal "6.1.0", conflict_data["direct_dependency_version"]
-    assert_equal "activerecord", conflict_data["blocking_dependency"]
-    assert_equal "6.1.0", conflict_data["blocking_dependency_version"]
-    assert_equal "sqlite3", conflict_data["target_dependency"]
-    assert_equal "1.4.0", conflict_data["target_dependency_version"]
-    assert_equal "~> 1.4", conflict_data["target_dependency_requirement"]
-    assert_equal ["rails", "activerecord", "sqlite3"], conflict_data["dependency_chain"]
+    conflict_group = json_data["conflicts"].first
+    assert_equal "rails", conflict_group["direct_dependency"]
+    assert_equal "6.1.0", conflict_group["direct_dependency_version"]
+    assert_equal 1, conflict_group["blocking_dependencies"].size
+
+    blocking_dep = conflict_group["blocking_dependencies"].first
+    assert_equal "activerecord", blocking_dep["blocking_dependency"]
+    assert_equal "6.1.0", blocking_dep["blocking_dependency_version"]
+    assert_equal "sqlite3", blocking_dep["target_dependency"]
+    assert_equal "1.4.0", blocking_dep["target_dependency_version"]
+    assert_equal "~> 1.4", blocking_dep["target_dependency_requirement"]
+    assert_equal ["rails", "activerecord", "sqlite3"], blocking_dep["dependency_chain"]
   end
 
   def test_multiple_conflicts_json_output
@@ -83,14 +88,15 @@ class TestJsonReporter < Minitest::Test
     results.add(conflict1)
     results.add(conflict2)
 
-    reporter = Bundler::Compat::Reporters::JsonReporter.new(results)
+    reporter = Bundler::Compat::Reporters::JsonReporter.new(results, target_version: "7.0.0")
 
     output = StringIO.new
     reporter.print(output: output)
 
     json_data = JSON.parse(output.string)
 
-    assert_equal 2, json_data["bundle_compatibility_report"]["conflicts_count"]
-    assert_equal 2, json_data["bundle_compatibility_report"]["conflicts"].size
+    assert_equal "7.0.0", json_data["target_rails_version"]
+    assert_equal 2, json_data["conflicts_count"]
+    assert_equal 2, json_data["conflicts"].size
   end
 end

--- a/test/bundler/test_text_reporter.rb
+++ b/test/bundler/test_text_reporter.rb
@@ -8,12 +8,13 @@ require "stringio"
 class TestTextReporter < Minitest::Test
   def test_reports_no_conflicts
     results = Bundler::Compat::Result::Group.new
-    reporter = Bundler::Compat::Reporters::TextReporter.new(results)
+    reporter = Bundler::Compat::Reporters::TextReporter.new(results, target_version: "7.0.0")
 
     output = StringIO.new
     reporter.print(output: output)
 
     assert_includes output.string, "Bundle Compatibility Report"
+    assert_includes output.string, "Target Rails version: 7.0.0"
     assert_includes output.string, "Found 0 conflicts(s)"
   end
 
@@ -32,7 +33,7 @@ class TestTextReporter < Minitest::Test
     results = Bundler::Compat::Result::Group.new
     results.add(conflict)
 
-    reporter = Bundler::Compat::Reporters::TextReporter.new(results)
+    reporter = Bundler::Compat::Reporters::TextReporter.new(results, target_version: "7.0.0")
 
     output = StringIO.new
     reporter.print(output: output)
@@ -72,7 +73,7 @@ class TestTextReporter < Minitest::Test
     results.add(conflict1)
     results.add(conflict2)
 
-    reporter = Bundler::Compat::Reporters::TextReporter.new(results)
+    reporter = Bundler::Compat::Reporters::TextReporter.new(results, target_version: "7.0.0")
 
     output = StringIO.new
     reporter.print(output: output)


### PR DESCRIPTION
JSON output is restructured to group conflicts by direct dependency like the plaintext report.

Both reporters now output the target version

```ruby
irb(main):001> target_version = "8.0"
=> "8.0"
irb(main):002> finder = Bundler::Compat::ConflictFinder.new(lockfile_contents: File.read("test/fixtures/B_Gemfile.lock"), target_version:)
=>
#<Bundler::Compat::ConflictFinder:0x00000001138bc090
...
irb(main):003> results = finder.search
=>
#<Bundler::Compat::Result::Group:0x0000000113f89580
...
irb(main):004> Bundler::Compat::Reporters::JsonReporter.new(results, target_version:).print
{
  "target_rails_version": "8.0",
  "conflicts_count": 6,
  "conflicts": [
    {
      "direct_dependency": "acts-as-taggable-on",
      "direct_dependency_version": "9.0.1",
      "blocking_dependencies": [
        {
          "blocking_dependency": "acts-as-taggable-on",
          "blocking_dependency_version": "9.0.1",
          "target_dependency": "activerecord",
          "target_dependency_version": "8.0",
          "target_dependency_requirement": ">= 6.0, < 7.1",
          "dependency_chain": "acts-as-taggable-on (9.0.1)"
        }
      ]
    },
    {
      "direct_dependency": "cucumber-rails",
      "direct_dependency_version": "2.6.1",
      "blocking_dependencies": [
        {
          "blocking_dependency": "cucumber-rails",
          "blocking_dependency_version": "2.6.1",
          "target_dependency": "railties",
          "target_dependency_version": "8.0",
          "target_dependency_requirement": ">= 5.0, < 8",
          "dependency_chain": "cucumber-rails (2.6.1)"
        }
      ]
    },
    {
      "direct_dependency": "exception_notification",
      "direct_dependency_version": "4.5.0",
      "blocking_dependencies": [
        {
          "blocking_dependency": "exception_notification",
          "blocking_dependency_version": "4.5.0",
          "target_dependency": "actionmailer",
          "target_dependency_version": "8.0",
          "target_dependency_requirement": ">= 5.2, < 8",
          "dependency_chain": "exception_notification (4.5.0)"
        },
        {
          "blocking_dependency": "exception_notification",
          "blocking_dependency_version": "4.5.0",
          "target_dependency": "activesupport",
          "target_dependency_version": "8.0",
          "target_dependency_requirement": ">= 5.2, < 8",
          "dependency_chain": "exception_notification (4.5.0)"
        }
      ]
    },
    {
      "direct_dependency": "font-awesome-rails",
      "direct_dependency_version": "4.7.0.8",
      "blocking_dependencies": [
        {
          "blocking_dependency": "font-awesome-rails",
          "blocking_dependency_version": "4.7.0.8",
          "target_dependency": "railties",
          "target_dependency_version": "8.0",
          "target_dependency_requirement": ">= 3.2, < 8.0",
          "dependency_chain": "font-awesome-rails (4.7.0.8)"
        }
      ]
    },
    {
      "direct_dependency": "paranoia",
      "direct_dependency_version": "2.6.1",
      "blocking_dependencies": [
        {
          "blocking_dependency": "paranoia",
          "blocking_dependency_version": "2.6.1",
          "target_dependency": "activerecord",
          "target_dependency_version": "8.0",
          "target_dependency_requirement": ">= 5.1, < 7.1",
          "dependency_chain": "paranoia (2.6.1)"
        }
      ]
    }
  ]
}
```